### PR TITLE
fix: Added Proguard rules to Android library

### DIFF
--- a/icicle/build.gradle
+++ b/icicle/build.gradle
@@ -13,13 +13,9 @@ android {
         targetSdkVersion rootProject.targetSdkVersion
         versionCode rootProject.versionCode
         versionName rootProject.versionName
+        consumerProguardFiles 'proguard-rules.pro'
     }
-    buildTypes {
-        release {
-            minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-        }
-    }
+
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_7
         targetCompatibility JavaVersion.VERSION_1_7

--- a/icicle/proguard-rules.pro
+++ b/icicle/proguard-rules.pro
@@ -9,9 +9,8 @@
 
 # Add any project specific keep options here:
 
-# If your project uses WebView with JS, uncomment the following
-# and specify the fully qualified class name to the JavaScript interface
-# class:
-#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
-#   public *;
-#}
+-keep class **$$Icicle { *; }
+-keep class com.segunfamisa.icicle.** { *; }
+-keepclasseswithmembers class * {
+    @com.segunfamisa.icicle.annotations.Freeze <fields>;
+}

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -4,6 +4,7 @@ apply plugin: 'android-apt'
 android {
     compileSdkVersion rootProject.compileSdkVersion
     buildToolsVersion rootProject.buildToolsVersion
+
     defaultConfig {
         applicationId "com.segunfamisa.icicle.sample"
         minSdkVersion rootProject.minSdkVersion
@@ -13,10 +14,12 @@ android {
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
+
     buildTypes {
         release {
-            minifyEnabled false
+            minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            signingConfig signingConfigs.debug
         }
     }
 


### PR DESCRIPTION
Issue #9 states problems with the Proguard configuration. Adding `consumerProguardFiles` handles all these configurations within the library itself. Therefore a manual configuration is obsolete.

Additionally the example is updated to use Proguard and the debug signing config in release mode. This helps validating the appliance of the Proguard configuration.